### PR TITLE
feat: Cleanup Test Classes and Dependencies - Meeds-io/MIPs#42 - EXO-62860

### DIFF
--- a/anti-bruteforce-services/pom.xml
+++ b/anti-bruteforce-services/pom.xml
@@ -1,68 +1,36 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <parent>
-        <artifactId>anti-bruteforce</artifactId>
-        <groupId>org.exoplatform.anti-bruteforce</groupId>
-        <version>1.1.x-SNAPSHOT</version>
-    </parent>
-    <modelVersion>4.0.0</modelVersion>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>anti-bruteforce</artifactId>
+    <groupId>org.exoplatform.anti-bruteforce</groupId>
+    <version>1.1.x-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>anti-bruteforce-services</artifactId>
-    <name>eXo Anti-bruteforce - Services</name>
+  <artifactId>anti-bruteforce-services</artifactId>
+  <name>eXo Anti-bruteforce - Services</name>
 
-    <properties>
-        <exo.test.coverage.ratio>0.79</exo.test.coverage.ratio>
-    </properties>
+  <properties>
+    <exo.test.coverage.ratio>0.79</exo.test.coverage.ratio>
+  </properties>
 
-    <dependencies>
-        <dependency>
-            <groupId>org.exoplatform.gatein.portal</groupId>
-            <artifactId>exo.portal.component.api</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.exoplatform.commons</groupId>
-            <artifactId>commons-component-common</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.exoplatform.gatein.portal</groupId>
-            <artifactId>exo.portal.component.identity</artifactId>
-            <scope>provided</scope>
-        </dependency>
+  <dependencies>
+    <dependency>
+      <groupId>org.exoplatform.commons</groupId>
+      <artifactId>commons-component-common</artifactId>
+      <scope>provided</scope>
+    </dependency>
 
-        <!-- Test -->
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-api-mockito2</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-module-junit4</artifactId>
-            <scope>test</scope>
-        </dependency>
-    </dependencies>
-    <build>
-      <plugins>
-        <plugin>
-          <artifactId>maven-surefire-plugin</artifactId>
-            <configuration>
-              <argLine>@{argLine} ${env.MAVEN_OPTS} --add-opens=java.sql/java.sql=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.util.regex=ALL-UNNAMED --add-opens=java.base/java.time=ALL-UNNAMED  --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens java.xml/jdk.xml.internal=ALL-UNNAMED </argLine>
-            </configuration>
-        </plugin>
-      </plugins>
-    </build>
+    <!-- Test -->
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
 </project>

--- a/anti-bruteforce-services/src/test/java/org/exoplatform/antibruteforce/utils/UtilsTest.java
+++ b/anti-bruteforce-services/src/test/java/org/exoplatform/antibruteforce/utils/UtilsTest.java
@@ -1,12 +1,30 @@
 package org.exoplatform.antibruteforce.utils;
 
+import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.when;
+
+import java.util.Locale;
+import java.util.ResourceBundle;
+
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+
 import org.exoplatform.commons.utils.CommonsUtils;
 import org.exoplatform.commons.utils.MailUtils;
 import org.exoplatform.services.mail.MailService;
 import org.exoplatform.services.mail.Message;
 import org.exoplatform.services.organization.OrganizationService;
 import org.exoplatform.services.organization.User;
-import org.exoplatform.services.organization.UserProfile;
 import org.exoplatform.services.organization.UserProfileHandler;
 import org.exoplatform.services.organization.idm.UserImpl;
 import org.exoplatform.services.organization.impl.UserProfileImpl;
@@ -15,34 +33,24 @@ import org.exoplatform.services.resources.ResourceBundleService;
 import org.exoplatform.web.WebAppController;
 import org.exoplatform.web.controller.metadata.ControllerDescriptor;
 import org.exoplatform.web.controller.router.Router;
-import org.gatein.common.util.EmptyResourceBundle;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.Mockito;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 
-import java.util.Locale;
-import java.util.Map;
-import java.util.ResourceBundle;
-
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.fail;
-import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.Mockito.times;
-import static org.powermock.api.mockito.PowerMockito.*;
-
-@RunWith(PowerMockRunner.class)
-@PowerMockIgnore({"javax.management.*", "javax.xml.*", "org.xml.*"})
+@RunWith(MockitoJUnitRunner.class)
 public class UtilsTest {
+
+  private static final MockedStatic<CommonsUtils> COMMONS_UTILS = mockStatic(CommonsUtils.class);
+
+  private static final MockedStatic<MailUtils>    MAIL_UTILS    = mockStatic(MailUtils.class);
 
   User user;
   OrganizationService organizationService;
 
   MailService mailService;
+
+  @AfterClass
+  public static void afterRunBare() throws Exception { // NOSONAR
+    COMMONS_UTILS.close();
+    MAIL_UTILS.close();
+  }
 
   @Before
   public void setUp() throws Exception {
@@ -56,26 +64,23 @@ public class UtilsTest {
     when(userProfileHandler.findUserProfileByName(any())).thenReturn(new UserProfileImpl(userName));
     when(organizationService.getUserProfileHandler()).thenReturn(userProfileHandler);
 
-    mockStatic(CommonsUtils.class);
     mailService = mock(MailService.class);
-    when(CommonsUtils.getService(MailService.class)).thenReturn(mailService);
+    COMMONS_UTILS.when(() -> CommonsUtils.getService(MailService.class)).thenReturn(mailService);
 
-    mockStatic(MailUtils.class);
-    when(MailUtils.getSenderEmail()).thenReturn("security@exo.com");
-    when(MailUtils.getSenderName()).thenReturn("Security Team");
+    MAIL_UTILS.when(() -> MailUtils.getSenderEmail()).thenReturn("security@exo.com");
+    MAIL_UTILS.when(() -> MailUtils.getSenderName()).thenReturn("Security Team");
 
     ResourceBundle bundle = new ExoResourceBundle("antibruteforce.accountLocked.email.subject=Locked email\r\n" + "key2=value");
     ResourceBundleService resourceBundleService = mock(ResourceBundleService.class);
     when(resourceBundleService.getResourceBundle(anyString(), any())).thenReturn(bundle);
-    when(CommonsUtils.getService(ResourceBundleService.class)).thenReturn(resourceBundleService);
+    COMMONS_UTILS.when(() -> CommonsUtils.getService(ResourceBundleService.class)).thenReturn(resourceBundleService);
 
     WebAppController webAppController = mock(WebAppController.class);
     when(webAppController.getRouter()).thenReturn(new Router(new ControllerDescriptor()));
-    when(CommonsUtils.getService(WebAppController.class)).thenReturn(webAppController);
+    COMMONS_UTILS.when(() -> CommonsUtils.getService(WebAppController.class)).thenReturn(webAppController);
   }
 
   @Test
-  @PrepareForTest({CommonsUtils.class, MailUtils.class})
   public void testSendAccountLockedEmail() {
     try {
       Utils.sendAccountLockedEmail(user, Locale.getDefault(), organizationService);


### PR DESCRIPTION
Prior to this change, the service testing was using powermock which is useless and restrictive in term of third party libraries dependency tree (complex to maintain with Java versions higher than JDK11).