### PR TITLE
feat: introduce eXo parent pom - EXO-64103

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <artifactId>addons-parent-exo-pom</artifactId>
+        <artifactId>addons-exo-parent-pom</artifactId>
         <groupId>org.exoplatform.addons</groupId>
         <version>17-security-fix-SNAPSHOT</version>
     </parent>

--- a/pom.xml
+++ b/pom.xml
@@ -4,9 +4,9 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <artifactId>addons-parent-pom</artifactId>
+        <artifactId>addons-parent-exo-pom</artifactId>
         <groupId>org.exoplatform.addons</groupId>
-        <version>17-exo-M01</version>
+        <version>17-security-fix-SNAPSHOT</version>
     </parent>
 
     <groupId>org.exoplatform.anti-bruteforce</groupId>
@@ -28,22 +28,14 @@
     </scm>
 
     <properties>
-        <org.exoplatform.gatein.portal.version>6.5.x-exo-SNAPSHOT</org.exoplatform.gatein.portal.version>
-        <org.exoplatform.commons.version>6.5.x-exo-SNAPSHOT</org.exoplatform.commons.version>
+        <org.exoplatform.commons-exo.version>6.5.x-security-fix-SNAPSHOT</org.exoplatform.commons-exo.version>
     </properties>
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>org.exoplatform.gatein.portal</groupId>
-                <artifactId>exo.portal.parent</artifactId>
-                <version>${org.exoplatform.gatein.portal.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.exoplatform.commons</groupId>
-                <artifactId>commons</artifactId>
-                <version>${org.exoplatform.commons.version}</version>
+                <groupId>org.exoplatform.commons-exo</groupId>
+                <artifactId>commons-exo</artifactId>
+                <version>${org.exoplatform.commons-exo.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>addons-exo-parent-pom</artifactId>
         <groupId>org.exoplatform.addons</groupId>
-        <version>17-security-fix-SNAPSHOT</version>
+        <version>17-M01</version>
     </parent>
 
     <groupId>org.exoplatform.anti-bruteforce</groupId>
@@ -28,7 +28,7 @@
     </scm>
 
     <properties>
-        <org.exoplatform.commons-exo.version>6.5.x-security-fix-SNAPSHOT</org.exoplatform.commons-exo.version>
+        <org.exoplatform.commons-exo.version>6.5.x-SNAPSHOT</org.exoplatform.commons-exo.version>
     </properties>
     <dependencyManagement>
         <dependencies>


### PR DESCRIPTION
This feature introduce new parent pom for eXo to be able to declare libraries versions used only in eXo, without impacting meeds